### PR TITLE
Scheme ID

### DIFF
--- a/docs/credit-note.xml
+++ b/docs/credit-note.xml
@@ -12,9 +12,9 @@
   <cbc:BuyerReference>0150abc</cbc:BuyerReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0208">1023290711</cbc:EndpointID>
+      <cbc:EndpointID schemeID="iso6523-actorid-upis">0208:1023290711</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0208">1023290711</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0208:1023290711</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SupplierTradingName Ltd.</cbc:Name>
@@ -44,7 +44,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0705969661</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0208">0705969661</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0208:0705969661</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>BuyerTradingName AS</cbc:Name>
@@ -121,7 +121,7 @@
       <cbc:Description>Description of item</cbc:Description>
       <cbc:Name>item name</cbc:Name>
       <cac:StandardItemIdentification>
-        <cbc:ID schemeID="0088">21382183120983</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0088:21382183120983</cbc:ID>
       </cac:StandardItemIdentification>
       <cac:OriginCountry>
         <cbc:IdentificationCode>NO</cbc:IdentificationCode>
@@ -152,7 +152,7 @@
       <cbc:Description>Description 2</cbc:Description>
       <cbc:Name>item name 2</cbc:Name>
       <cac:StandardItemIdentification>
-        <cbc:ID schemeID="0088">21382183120983</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0088:21382183120983</cbc:ID>
       </cac:StandardItemIdentification>
       <cac:OriginCountry>
         <cbc:IdentificationCode>NO</cbc:IdentificationCode>

--- a/docs/invoice.xml
+++ b/docs/invoice.xml
@@ -13,9 +13,9 @@
   <cbc:BuyerReference>0150abc</cbc:BuyerReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9944">nl862637223B02</cbc:EndpointID>
+      <cbc:EndpointID schemeID="iso6523-actorid-upis">9944:nl862637223B02</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="9944">nl862637223B02</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">9944:nl862637223B02</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SupplierTradingName Ltd.</cbc:Name>
@@ -43,9 +43,9 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0208">0705969661</cbc:EndpointID>
+      <cbc:EndpointID schemeID="iso6523-actorid-upis">0208:0705969661</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="0208">0705969661</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0208:0705969661</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>BuyerTradingName AS</cbc:Name>
@@ -79,7 +79,7 @@
   <cac:Delivery>
     <cbc:ActualDeliveryDate>2025-11-01</cbc:ActualDeliveryDate>
     <cac:DeliveryLocation>
-      <cbc:ID schemeID="0088">9483759475923478</cbc:ID>
+      <cbc:ID schemeID="iso6523-actorid-upis">0088:9483759475923478</cbc:ID>
       <cac:Address>
         <cbc:StreetName>Delivery street 2</cbc:StreetName>
         <cbc:AdditionalStreetName>Building 56</cbc:AdditionalStreetName>
@@ -156,7 +156,7 @@
       <cbc:Description>Description of item</cbc:Description>
       <cbc:Name>item name</cbc:Name>
       <cac:StandardItemIdentification>
-        <cbc:ID schemeID="0088">21382183120983</cbc:ID>
+        <cbc:ID schemeID="iso6523-actorid-upis">0088:21382183120983</cbc:ID>
       </cac:StandardItemIdentification>
       <cac:OriginCountry>
         <cbc:IdentificationCode>NO</cbc:IdentificationCode>

--- a/proxy/src/parse.ts
+++ b/proxy/src/parse.ts
@@ -23,9 +23,21 @@ export function parseDocument(documentXml: string): { sender: string | undefined
   }
   const sender = jObj[docType]?.['cac:AccountingSupplierParty']?.['cac:Party']?.['cbc:EndpointID'];
   const recipient = jObj[docType]?.['cac:AccountingCustomerParty']?.['cac:Party']?.['cbc:EndpointID'];
+  if (sender['@_schemeID'] !== 'iso6523-actorid-upis') {
+    throw new Error(`Unsupported sender schemeID ${sender['@_schemeID']}, only iso6523-actorid-upis is supported`);
+  }
+  if (recipient['@_schemeID'] !== 'iso6523-actorid-upis') {
+    throw new Error(`Unsupported recipient schemeID ${recipient['@_schemeID']}, only iso6523-actorid-upis is supported`);
+  }
+  if (!sender['#text']) {
+    throw new Error('Missing sender EndpointID text');
+  }
+  if (!recipient['#text']) {
+    throw new Error('Missing recipient EndpointID text');
+  }
   return {
-    sender: `${sender['@_schemeID']}:${sender['#text']}`,
-    recipient: `${recipient['@_schemeID']}:${recipient['#text']}`,
+    sender: sender['#text'],
+    recipient: recipient['#text'],
     docType: docType === 'Invoice' ? 'Invoice' : docType === 'CreditNote' ? 'CreditNote' : undefined,
   };
 }


### PR DESCRIPTION
According to the [Scrada docs](https://www.postman.com/scrada/overview/documentation/pcpubjp/scrada-peppol-only) the scheme ID should always be 'iso6523-actorid-upis' and the ID itself exist of 2 parts separated by a colon